### PR TITLE
Fix property details modal

### DIFF
--- a/src/client/pages/Details.fs
+++ b/src/client/pages/Details.fs
@@ -5,7 +5,7 @@ open Fable.Helpers.React.Props
 open PropertyMapper.Contracts
 open Fable
 
-let view txn =
+let private content txn =
     let field name value =
         value
         |> Option.map(fun v ->
@@ -15,31 +15,32 @@ let view txn =
             ])
         |> Option.defaultValue (div [] [])
 
-    div [ ClassName "modal fade"; Id "exampleModal"; Role "dialog"; unbox ("aria-labelledby", "exampleModalLabel"); unbox ("aria-hidden", "true") ] [
-        div [ ClassName "modal-dialog"; Role "document" ] [
-            div [ ClassName "modal-content" ] [
-                div [ ClassName "modal-header" ] [
-                    h5 [ ClassName "modal-title"; Id "exampleModalLabel" ] [ str txn.Address.FirstLine ]
-                    button [ Type "button"; ClassName "close"; unbox ("data-dismiss", "modal"); unbox ("aria-label", "Close") ] [
-                        span [ unbox ("aria-hidden", true) ] [ str "x" ]
-                    ]
-                ]
-                div [ ClassName "modal-body" ] [
-                    field "Building / Street" (Some txn.Address.FirstLine)
-                    field "Town" (Some txn.Address.TownCity)
-                    field "District" (Some txn.Address.District)
-                    field "County" (Some txn.Address.County)
-                    field "Locality" txn.Address.Locality
-                    field "Post Code" txn.Address.PostCode
-                    field "Price" (Some(sprintf "£%s" (txn.Price |> commaSeparate)))
-                    field "Date of Transfer" (Some (txn.DateOfTransfer.ToShortDateString()))
-                    field "Property Type" (txn.BuildDetails.PropertyType |> Option.map(fun pt -> pt.Description))
-                    field "Build Type" (Some (string txn.BuildDetails.Build.Description))
-                    field "Contract" (Some (string txn.BuildDetails.Contract.Description))
-                ]
-                div [ ClassName "modal-footer" ] [
-                    button [ Type "button"; ClassName "btn btn-primary"; unbox ("data-dismiss", "modal") ] [ str "Close" ]
-                ]
+    div [ ClassName "modal-content" ] [
+        div [ ClassName "modal-header" ] [
+            h5 [ ClassName "modal-title"; Id "exampleModalLabel" ] [ str txn.Address.FirstLine ]
+            button [ Type "button"; ClassName "close"; unbox ("data-dismiss", "modal"); unbox ("aria-label", "Close") ] [
+                span [ unbox ("aria-hidden", true) ] [ str "x" ]
             ]
         ]
+        div [ ClassName "modal-body" ] [
+            field "Building / Street" (Some txn.Address.FirstLine)
+            field "Town" (Some txn.Address.TownCity)
+            field "District" (Some txn.Address.District)
+            field "County" (Some txn.Address.County)
+            field "Locality" txn.Address.Locality
+            field "Post Code" txn.Address.PostCode
+            field "Price" (Some(sprintf "£%s" (txn.Price |> commaSeparate)))
+            field "Date of Transfer" (Some (txn.DateOfTransfer.ToShortDateString()))
+            field "Property Type" (txn.BuildDetails.PropertyType |> Option.map(fun pt -> pt.Description))
+            field "Build Type" (Some (string txn.BuildDetails.Build.Description))
+            field "Contract" (Some (string txn.BuildDetails.Contract.Description))
+        ]
+        div [ ClassName "modal-footer" ] [
+            button [ Type "button"; ClassName "btn btn-primary"; unbox ("data-dismiss", "modal") ] [ str "Close" ]
+        ]
+    ]
+
+let view txn =
+    div [ ClassName "modal fade"; Id "exampleModal"; Role "dialog"; unbox ("aria-labelledby", "exampleModalLabel"); unbox ("aria-hidden", "true") ] [
+        div [ ClassName "modal-dialog"; Role "document" ] (match txn with Some txn -> [ content txn ] | None -> [])
     ]

--- a/src/client/pages/Details.fs
+++ b/src/client/pages/Details.fs
@@ -11,7 +11,7 @@ let private content txn =
         |> Option.map(fun v ->
             div [ ClassName "form-group row" ] [
                 label [ HtmlFor name; ClassName "col-sm-4 col-form-label" ] [ str name ]
-                div [ ClassName "col-sm-8" ] [ input [ Type "text"; ClassName "form-control-plaintext"; Id name; Value v ] ]
+                div [ ClassName "col-sm-8" ] [ input [ Type "text"; ClassName "form-control-plaintext"; Id name; Value v; ReadOnly true ] ]
             ])
         |> Option.defaultValue (div [] [])
 

--- a/src/client/pages/Search.fs
+++ b/src/client/pages/Search.fs
@@ -105,7 +105,7 @@ let viewResults searchResults dispatch =
 let view model dispatch =
     let progressBarVisibility = match model.Status with | Searching -> "visible" | Displaying -> "invisible"
     div [ ClassName "col" ] [
-        yield! model.Selected |> function Some property -> [ Details.view property ] | None -> []
+        yield Details.view model.Selected
         yield div [ ClassName "border rounded m-3 p-3 bg-light" ] [
             div [ ClassName "form-group" ] [
                 label [ HtmlFor "searchValue" ] [ str "Search for" ]


### PR DESCRIPTION
Fixes #25 by always rendering the modal div as hidden even before a property is selected, and by setting fields to be read only.